### PR TITLE
handle case where remote is undefined, use ${remote- instead of remote:

### DIFF
--- a/src/gt-remote.sh
+++ b/src/gt-remote.sh
@@ -98,7 +98,7 @@ function gt_remote_add() {
 		EOM
 	)
 	parseArguments params "$examples" "$GT_VERSION" "$@"
-	if ! [[ -v pullDir ]]; then pullDir="lib/${remote:'remote-not-defined'}"; fi
+	if ! [[ -v pullDir ]]; then pullDir="lib/${remote-'remote-not-defined'}"; fi
 	if ! [[ -v unsecure ]]; then unsecure=false; fi
 	if ! [[ -v workingDir ]]; then workingDir="$defaultWorkingDir"; fi
 	exitIfNotAllArgumentsSet params "$examples" "$GT_VERSION"


### PR DESCRIPTION
because set -u still kicks in when using `:` but does not when using - and we don't need to assign a value to remote as we exit a few line further below anyways



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.13.2/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
