### PR TITLE
first check if there is a var AUTO_PR_FORK_NAME and then secrets

### DIFF
--- a/.github/workflows/gt-update.yml
+++ b/.github/workflows/gt-update.yml
@@ -107,4 +107,4 @@ jobs:
           body: "following the changes after running `gt update -r \"${{ matrix.remote }}\"` and reset gpg keys"
           delete-branch: true
           token: ${{ secrets.AUTO_PR_TOKEN }}
-          push-to-fork: ${{ secrets.AUTO_PR_FORK_NAME }}
+          push-to-fork: ${{ vars.AUTO_PR_FORK_NAME != '' && vars.AUTO_PR_FORK_NAME || secrets.AUTO_PR_FORK_NAME }}


### PR DESCRIPTION
we could also just switch to vars but why not keep secrets, maybe someone has a private fork and doesn't want to expose it



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.16.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
