### PR TITLE
perform update after update in gt-update.yml to re-trigger pull-hook

### DIFF
--- a/.github/workflows/gt-update.yml
+++ b/.github/workflows/gt-update.yml
@@ -93,7 +93,7 @@ jobs:
       - name: gt update
         id: gt_update
         run: |
-          gt update -r "${{ matrix.remote }}"
+          gt update -r "${{ matrix.remote }}" && gt update -r "${{ matrix.remote }}"
           echo "remote_version=$(git --git-dir='.gt/remotes/${{ matrix.remote}}/repo/.git' tag | sort --version-sort | tail -n 1)" >> $GITHUB_OUTPUT
       - name: git status
         run: git status


### PR DESCRIPTION
Might be the pull-hook depends on files which were just pulled, better to update again to see those changes as well (and not only during the next run)



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.17.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
