### PR TITLE
only verify files if gpg dir contains trustdb.gpg in case of unsecure

### DIFF
--- a/src/gt-pull.sh
+++ b/src/gt-pull.sh
@@ -182,6 +182,8 @@ function gt_pull() {
 				if [[ $unsecure == true ]]; then
 					logWarning "no GPG key found, won't be able to verify files (which is OK because '%s true' was specified)" "$unsecureParamPattern"
 					doVerification=false
+					# we initialiseGpgDir so that we don't try it next time
+					initialiseGpgDir "$gpgDir"
 				else
 					die "no public keys for remote \033[0;36m%s\033[0m defined in %s" "$remote" "$publicKeysDir"
 				fi
@@ -205,7 +207,12 @@ function gt_pull() {
 			fi
 		fi
 		if [[ $unsecure == true && $doVerification == true ]]; then
-			logInfo "gpg key found going to perform verification even though '%s true' was specified" "$unsecureParamPattern"
+			local trustDb="$gpgDir/trustdb.gpg"
+			if [[ -f $trustDb ]]; then
+				logInfo "gpg seems to be initialised (found %s), going to perform verification even though '%s true' was specified" "$unsecureParamPattern" "$trustDb"
+			else
+				doVerification=false
+			fi
 		fi
 	fi
 


### PR DESCRIPTION
because we create the gpg dir (empty) in case someone uses gt remote add ... --unsecure true

and in such a case the gpg dir contains no gpg keys and hence we cannot verify files.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.19.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
