### PR TITLE
we warn if no files where pulled for remote but fail to clean up repo

### DIFF
--- a/src/gt-pull.sh
+++ b/src/gt-pull.sh
@@ -81,7 +81,9 @@ sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 
 function gt_pull_cleanupRepo() {
 	local -r repository=$1
-	find "$repository" -maxdepth 1 -type d -not -path "$repository" -not -name ".git" -exec rm -r {} \;
+	if [[ -d $repository ]]; then
+		find "$repository" -maxdepth 1 -type d -not -path "$repository" -not -name ".git" -exec rm -r {} \;
+	fi
 }
 
 function gt_pull_noop() {


### PR DESCRIPTION
i.e. check in gt_pull_cleanupRepo if the repo exists and only then delete all pulled files



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.19.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
