### PR TITLE
only support one signing-key per remote

### DIFF
--- a/src/common-constants.source.sh
+++ b/src/common-constants.source.sh
@@ -49,3 +49,5 @@ local -r pathParamPattern="-p|$pathParamPatternLong"
 
 local -r chopPathParamPatternLong='--chop-path'
 local -r chopPathParamPattern="$chopPathParamPatternLong"
+
+local -r signingKeyAsc='signing-key.public.asc'


### PR DESCRIPTION
which means:
- expect signing-key.public.asc in the .gt folder of remotes
- expect signing-key.public.asc in the public-keys folder of a remote
- adjust error messages



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.19.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
