### PR TITLE
don't set a trap for SIGINT (EXIT trap is still called)

### DIFF
--- a/src/gt-pull.sh
+++ b/src/gt-pull.sh
@@ -80,6 +80,7 @@ sourceOnce "$dir_of_tegonal_scripts/utility/io.sh"
 sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 
 function gt_pull_cleanupRepo() {
+	# note, we want to cleanup also for normal exits, so no need to check for $?
 	local -r repository=$1
 	if [[ -d $repository ]]; then
 		find "$repository" -maxdepth 1 -type d -not -path "$repository" -not -name ".git" -exec rm -r {} \;
@@ -266,7 +267,7 @@ function gt_pull() {
 
 	# we want to expand $repo here and not when signal happens (as $repo might be out of scope)
 	# shellcheck disable=SC2064
-	trap "gt_pull_cleanupRepo '$repo'" EXIT SIGINT
+	trap "gt_pull_cleanupRepo '$repo'" EXIT
 
 	askToDeleteAndReInitialiseGitDirIfRemoteIsBroken "$workingDirAbsolute" "$remote"
 

--- a/src/gt-remote.sh
+++ b/src/gt-remote.sh
@@ -52,12 +52,11 @@ function gt_remote_cleanupRemoteOnUnexpectedExit() {
 	local -r result=$?
 
 	local -r remoteDir=$1
-	local -r currentDir=$2
-	shift 2 || traceAndDie "could not shift by 2"
-
 	if ! ((result == 0)) && [[ -d $remoteDir ]]; then
-		# delete the remoteDir and its content
-		deleteDirChmod777 "$remoteDir"
+		if [[ -d $remoteDir ]]; then
+			# delete the remoteDir and its content
+			deleteDirChmod777 "$remoteDir"
+		fi
 		# re-add so that one can still establish trust manually
 		mkdir "$remoteDir"
 	fi
@@ -162,7 +161,7 @@ function gt_remote_add() {
 
 	# we want to expand $remoteDir and $currentDir here and not when signal happens (as they might be out of scope)
 	# shellcheck disable=SC2064
-	trap "gt_remote_cleanupRemoteOnUnexpectedExit '$remoteDir' '$currentDir'" EXIT SIGINT
+	trap "gt_remote_cleanupRemoteOnUnexpectedExit '$remoteDir'" EXIT
 
 	echo "$pullDirParamPatternLong \"$pullDir\"" >"$pullArgsFile" || logWarningCouldNotWritePullArgs "the pull directory" "$pullDir" "$pullArgsFile" "$pullDirParamPatternLong" "$remote"
 


### PR DESCRIPTION
also a SIGINT trap without an own exit will cause that the function execution continues even if set -e is set if the function is called in a conditional (while and so on). i.e. not only set -e is deactivated but also a trap for SIGINT without explicit exit no longer exits



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v0.19.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
