### PR TITLE
fix setEntryVariables exitIfVariablesNotDeclared expects the variables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -240,12 +240,14 @@ function install() {
 			local symlinkDir homeLocalBin
 			symlinkDir=$(dirname "$symbolicLink")
 			homeLocalBin=$(readlink -m "$HOME/.local/bin")
+
+			# trying to help the user why the installation failed
 			if [[ -n "$fpath_output" && $symlinkDir == "$homeLocalBin" ]]; then
 				echo ""
-				logError "looks like something went wrong. You seem using zsh and the symlink directory (%s) is in a typical BASH location.\nMake sure you have added it to your PATH in your .zshrc -- i.e. add the following:\nexport PATH=\"\$PATH:\$HOME/.local/bin\"" "$symlinkDir"
+				logError "looks like something went wrong. You seem using zsh and the parent directory of the symlink (%s) is a typical BASH location.\nMake sure you have added it to your PATH in your .zshrc -- i.e. add the following if it is missing:\nexport PATH=\"\$PATH:\$HOME/.local/bin\"\n\nFollowing the current PATH:\n%s" "$symlinkDir" "$PATH"
 				echo ""
 			else
-				logError "looks like something is wrong, make sure %s is in your PATH" "$symlinkDir"
+				logError "looks like something is wrong, make sure %s is in your PATH and " "$symlinkDir"
 			fi
 			exit 1
 		fi

--- a/src/gt.sh
+++ b/src/gt.sh
@@ -47,13 +47,13 @@ if ! [[ -v dir_of_gt ]]; then
 	declare intermediateSource=${BASH_SOURCE[0]:-$0}
 	declare intermediateDir=""
 	while [[ -L $intermediateSource ]]; do
-		intermediateDir=$(cd -P "$(dirname "$intermediateSource")" >/dev/null && pwd)
+		intermediateDir=$(cd -P "$(dirname "$intermediateSource")" >/dev/null && pwd 2>/dev/null)
 		intermediateSource=$(readlink "$intermediateSource")
 		if [[ $intermediateSource != /* ]]; then
 			intermediateSource=$intermediateDir/$intermediateSource
 		fi
 	done
-	dir_of_gt=$(cd -P "$(dirname "$intermediateSource")" >/dev/null && pwd)
+	dir_of_gt=$(cd -P "$(dirname "$intermediateSource")" >/dev/null && pwd 2>/dev/null)
 	readonly dir_of_gt
 fi
 

--- a/src/pulled-utils.sh
+++ b/src/pulled-utils.sh
@@ -130,7 +130,7 @@ function exitIfHeaderOfPulledTsvIsWrong() {
 
 function setEntryVariables() {
 	local -ra variableNames=(entryTag entryFile entryRelativePath entryTagFilter entrySha)
-	exitIfVariablesNotDeclared variableNames
+	exitIfVariablesNotDeclared "${variableNames[@]}"
 
 	# shellcheck disable=SC2034
 	IFS=$'\t' read -r "${variableNames[@]}" <<<"$1" || die "could not setEntryVariables for entry:\n%s" "$1"


### PR DESCRIPTION
and not an array containing the variables. tegonal-scripts prio to v4.5.1 contained a bug and ignored the first variable, that's why we did not run earlier into this bug



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v1.2.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
