### PR TITLE
move further checks from gt_pull_internal_... into gt_pull_parse_args

### DIFF
--- a/scripts/prepare-next-dev-cycle.sh
+++ b/scripts/prepare-next-dev-cycle.sh
@@ -43,13 +43,13 @@ function prepareNextDevCycle() {
 		additionalPattern "$additionalPatternParamPattern" "is ignored as additional pattern is specified internally, still here as release-files uses this argument"
 		beforePrFn "$beforePrFnParamPattern" "$beforePrFnParamDocu"
 	)
-	parseArguments params "" "$GT_VERSION" "$@"
+	parseArguments params "" "$GT_VERSION" "$@" || return $?
 	# we don't check if all args are set (and neither set default values) as we currently don't use
 	# any param in here but just delegate to prepareFilesNextDevCycle.
 
 	function prepare_next_afterVersionHook() {
 		local version projectsRootDir additionalPattern
-		parseArguments afterVersionHookParams "" "$GT_VERSION" "$@"
+		parseArguments afterVersionHookParams "" "$GT_VERSION" "$@" || return $?
 
 		updateVersionInNonShFiles -v "$version-SNAPSHOT" --project-dir "$projectsRootDir" --pattern "$additionalPattern"
 	}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,7 +46,7 @@ function release() {
 		nextVersion "$nextVersionParamPattern" "$nextVersionParamDocu"
 		prepareOnly "$prepareOnlyParamPattern" "$prepareOnlyParamDocu"
 	)
-	parseArguments params "" "$GT_VERSION" "$@"
+	parseArguments params "" "$GT_VERSION" "$@" || return $?
 	# we don't check if all args are set (and neither set default values) as we currently don't use
 	# any param in here but just delegate to releaseFiles.
 
@@ -64,7 +64,7 @@ function release() {
 
 	function release_afterVersionHook() {
 		local version projectsRootDir additionalPattern
-		parseArguments afterVersionHookParams "" "$GT_VERSION" "$@"
+		parseArguments afterVersionHookParams "" "$GT_VERSION" "$@" || return $?
 
 		updateVersionInNonShFiles -v "$version" --project-dir "$projectsRootDir" --pattern "$additionalPattern"
 

--- a/scripts/update-version-in-non-sh-files.sh
+++ b/scripts/update-version-in-non-sh-files.sh
@@ -39,7 +39,7 @@ sourceOnce "$dir_of_tegonal_scripts/utility/parse-args.sh"
 function updateVersionInNonShFiles() {
 	source "$dir_of_tegonal_scripts/releasing/common-constants.source.sh" || traceAndDie "could not source common-constants.source.sh"
 	local version projectsRootDir additionalPattern
-	parseArguments afterVersionHookParams "" "$GT_VERSION" "$@"
+	parseArguments afterVersionHookParams "" "$GT_VERSION" "$@" || return $?
 
 	local -ra additionalScripts=(
 		"$projectsRootDir/install.sh"

--- a/spec/smoke_spec.sh
+++ b/spec/smoke_spec.sh
@@ -33,6 +33,7 @@ Describe 'smoke specs /'
 
 	Parameters:value pull re-pull reset update self-update 'remote add' 'remote remove' 'remote list'
 	It "gt $1 --help"
+		# shellcheck disable=SC2086  # we want that e.g. 'remote add' is split
 		When call gt $1 --help
 		The status should be successful
 		The output should include 'Parameters'

--- a/src/gt-re-pull.sh
+++ b/src/gt-re-pull.sh
@@ -129,26 +129,17 @@ function gt_re_pull() {
 		local repo
 		source "$dir_of_gt/paths.source.sh" || traceAndDie "could not source paths.source.sh"
 
-		local args
-		#shellcheck disable=SC2310		# we know that set -e is disabled for gt_pull_parse_args, we always use || in gt_pull_parse_args so all good
-		args=$(
-			gt_pull_parse_args "$currentDir" \
-				"$workingDirParamPatternLong" "$workingDirAbsolute" \
-				"$remoteParamPatternLong" "$remote" \
-				"$tagParamPatternLong" "tag-to-replace" \
-				"$pathParamPatternLong" "source-to-replace" \
-				"$pullDirParamPatternLong" "pull-dir-to-replace" \
-				"$chopPathParamPatternLong" true \
-				"$targetFileNamePatternLong" "target-to-replace" \
-				"$tagFilterParamPatternLong" "tag-filter-to-replace" \
-				"$autoTrustParamPatternLong" "$autoTrust"
-		) || {
-			local exitCode=$?
-			echo "$args"
-			return "$exitCode"
-		}
 		local -a gt_pull_parsed_args
-		mapfile -t gt_pull_parsed_args <<<"$args"
+		gt_pull_parse_args gt_pull_parsed_args "$currentDir" \
+			"$workingDirParamPatternLong" "$workingDirAbsolute" \
+			"$remoteParamPatternLong" "$remote" \
+			"$tagParamPatternLong" "tag-to-replace" \
+			"$pathParamPatternLong" "source-to-replace" \
+			"$pullDirParamPatternLong" "pull-dir-to-replace" \
+			"$chopPathParamPatternLong" true \
+			"$targetFileNamePatternLong" "target-to-replace" \
+			"$tagFilterParamPatternLong" "tag-filter-to-replace" \
+			"$autoTrustParamPatternLong" "$autoTrust" || return $?
 
 		function gt_re_pull_rePullInternal_callback() {
 			local entryTag entryFile entryRelativePath entryAbsolutePath entryTagFilter _entrySha512

--- a/src/gt-update.sh
+++ b/src/gt-update.sh
@@ -151,25 +151,17 @@ function gt_update() {
 		# we parse the arguments once so that we don't have to re-parse them for every file we might unless we only --list
 		# the updates
 		if [[ $list != true ]]; then
-			local args
-			#shellcheck disable=SC2310		# we know that set -e is disabled for gt_pull_parse_args, we always use || in gt_pull_parse_args so all good
-			args=$(
-				gt_pull_parse_args "$currentDir" \
-					"$workingDirParamPatternLong" "$workingDirAbsolute" \
-					"$remoteParamPatternLong" "$remote" \
-					"$tagParamPatternLong" "tag-to-replace" \
-					"$pathParamPatternLong" "source-to-replace" \
-					"$pullDirParamPatternLong" "pull-dir-to-replace" \
-					"$chopPathParamPatternLong" true \
-					"$targetFileNamePatternLong" "target-to-replace" \
-					"$tagFilterParamPatternLong" "tag-filter-to-replace" \
-					"$autoTrustParamPatternLong" "$autoTrust"
-			) || {
-				local exitCode=$?
-				echo "$args"
-				return "$exitCode"
-			}
-			mapfile -t gt_pull_parsed_args <<<"$args"
+			local -a gt_pull_parsed_args
+			gt_pull_parse_args gt_pull_parsed_args "$currentDir" \
+				"$workingDirParamPatternLong" "$workingDirAbsolute" \
+				"$remoteParamPatternLong" "$remote" \
+				"$tagParamPatternLong" "tag-to-replace" \
+				"$pullDirParamPatternLong" "pull-dir-to-replace" \
+				"$pathParamPatternLong" "source-to-replace" \
+				"$chopPathParamPatternLong" true \
+				"$targetFileNamePatternLong" "target-to-replace" \
+				"$tagFilterParamPatternLong" "tag-filter-to-replace" \
+				"$autoTrustParamPatternLong" "$autoTrust" || return $?
 		fi
 
 		function gt_update_rePullInternal_callback() {


### PR DESCRIPTION
enough to do them once. Also don't use parseFnArgs here, if we want to make it faster we don't want to lose time again with parsing



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v1.3.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
