### PR TITLE
make determineDefaultBranch more robust, don't rely on remote show

### DIFF
--- a/src/utils.sh
+++ b/src/utils.sh
@@ -369,11 +369,14 @@ function determineDefaultBranch() {
 	local repo
 	source "$dir_of_gt/paths.source.sh" || traceAndDie "could not source paths.source.sh"
 
-	git --git-dir "$repo/.git" remote show "$remote" | sed -n '/HEAD branch/s/.*: //p' ||
-		(
-			logWarning >&2 "was not able to determine default branch for remote \033[0;36m%s\033[0m, going to use main" "$remote"
-			echo "main"
-		)
+	local defaultBranch
+	defaultBranch=$(git --git-dir "$repo/.git" ls-remote --symref "$remote" HEAD 2>/dev/null | sed -n 's|^ref: refs/heads/\(.*\)\tHEAD$|\1|p' || echo "")
+	if [[ -n $defaultBranch ]]; then
+		echo "$defaultBranch"
+	else
+		logWarning >&2 "was not able to determine default branch for remote \033[0;36m%s\033[0m, going to use main" "$remote"
+		echo "main"
+	fi
 }
 
 function checkoutGtDir() {


### PR DESCRIPTION
because remote show differs depending on the current locale. Use ls-remote --symref instead



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v1.4.3/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
