### PR TITLE
fix the usage of tab in grep, \t is interpreted as t

### DIFF
--- a/src/pulled-utils.sh
+++ b/src/pulled-utils.sh
@@ -162,7 +162,10 @@ function grepPulledEntryByFile() {
 	local -r pulledTsv=$1
 	local -r file=$2
 	shift 2 || traceAndDie "could not shift by 2"
-	grep -E "^[^\t]+	$file" "$@" "$pulledTsv"
+	local escapedFile
+	# shellcheck disable=SC2016	# $ in regex is not a variable, all good
+	escapedFile="$(printf '%s\n' "$file" | sed -e 's/[.[\*^$()+?{}|\\]/\\&/g')"
+	grep -E "^[^	]+	$escapedFile" "$@" "$pulledTsv"
 }
 
 function replacePulledEntry() {


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v1.6.2/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
