### PR TITLE
fix argument documentation and reduce duplication where possible

### DIFF
--- a/src/commands/common_args.rs
+++ b/src/commands/common_args.rs
@@ -1,0 +1,33 @@
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args)]
+pub struct RemoteArg {
+	/// Name identifying this remote
+	#[arg(short = 'r', long)]
+	pub remote: String,
+}
+
+#[derive(Args)]
+pub struct TagFilterArg {
+	/// (Optional) Define a regexp pattern to filter available tags when determining the latest tag
+	#[arg(long)]
+	pub tag_filter: Option<String>,
+}
+
+#[derive(Args)]
+pub struct WorkingDirectoryArg {
+	/// (Optional) Path which gt shall use as working directory
+	#[arg(short = 'w', long, default_value = ".gt")]
+	pub working_directory: PathBuf,
+}
+
+#[derive(Args)]
+pub struct PullCommonArgs {
+	/// (Optional) If defined and GPG is not set up yet, then all keys in <WORKING_DIRECTORY>/remotes/<REMOTE>/public-keys/*.asc are imported without manual consent
+	#[arg(long, default_value_t = false)]
+	pub auto_trust: bool,
+
+	#[command(flatten)]
+	pub working_directory: WorkingDirectoryArg,
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,10 +1,10 @@
+pub mod common_args;
 pub mod pull;
+pub mod remote;
 pub mod repull;
 pub mod reset;
 pub mod self_update;
 pub mod update;
-
-pub mod remote;
 
 use clap::Subcommand;
 

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -1,51 +1,47 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::{PullCommonArgs, RemoteArg, TagFilterArg};
 
 #[derive(Args)]
 pub struct PullArgs {
-	/// Name of the remote repository
-	#[arg(short = 'r', long)]
-	pub remote: String,
+	#[command(flatten)]
+	pub remote: RemoteArg,
 
 	/// Git tag used to pull the file/directory
 	#[arg(short = 't', long)]
 	pub tag: String,
 
+	//TODO 2.0.0 I think path should not be an option but an argument
 	/// Path in remote repository which shall be pulled (file or directory)
 	#[arg(short = 'p', long)]
 	pub path: String,
 
-	/// Directory into which files are pulled -- default: pull directory of this remote
+	/// (Optional) Directory into which files are pulled [default: pull directory of this remote (defined during "remote add" and stored in <WORKING_DIRECTORY>/<REMOTE>/pull.args)]
 	#[arg(short = 'd', long)]
 	pub directory: Option<String>,
 
-	/// If set, files are put into the pull directory without the path specified
+	/// (Optional) If defined, then files are put into the pull directory without the path specified. For files this means they are put directly into the pull directory
 	#[arg(long)]
 	pub chop_path: bool,
 
-	/// If you want to use a different file name then the one specified in the remote
+	/// (Optional) If you want to use a different file name then the one specified in the remote [default: name as specified in the remote]
 	#[arg(long)]
 	pub target_file_name: Option<String>,
 
-	/// Define a regexp pattern to filter available tags when determining the latest tag
-	#[arg(long)]
-	pub tag_filter: Option<String>,
-
-	/// If set and GPG is not set up yet, then all keys are imported without manual consent
-	#[arg(long)]
-	pub auto_trust: bool,
-
-	/// If set, the remote does not need to have GPG key(s) defined
-	#[arg(long)]
+	/// (Optional) If defined, the remote does not need to have GPG key(s) defined in gpg database or at <WORKING_DIRECTORY>/remotes/<REMOTE>/*.asc
+	#[arg(long, default_value_t = false)]
 	pub unsecure: bool,
 
-	/// If set, implies --unsecure and does not verify even if gpg keys are in store
+	/// (Optional) If defined, implies --unsecure and does not verify even if gpg keys are in store or at <WORKING_DIRECTORY>/remotes/<REMOTE>/*.asc
 	#[arg(long)]
 	pub unsecure_no_verification: bool,
 
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	/// Define a regexp pattern to filter available tags when determining the latest tag
+	#[command(flatten)]
+	pub tag_filter: TagFilterArg,
+
+	#[command(flatten)]
+	pub pull_common: PullCommonArgs,
 }
 
 pub fn run(_args: PullArgs) {

--- a/src/commands/remote/add.rs
+++ b/src/commands/remote/add.rs
@@ -1,30 +1,26 @@
 use clap::Args;
 
+use crate::commands::common_args::{RemoteArg, WorkingDirectoryArg};
+
 #[derive(Args)]
 pub struct RemoteAddArgs {
-	/// Name identifying this remote
-	#[arg(short = 'r', long)]
-	pub remote: String,
+	#[command(flatten)]
+	pub remote: RemoteArg,
 
 	/// URL of the remote repository
 	#[arg(short = 'u', long)]
 	pub url: String,
 
-	/// Directory into which files are pulled -- default: lib/<remote>
+	/// (Optional) Directory into which files are pulled [default: lib/<REMOTE>]
 	#[arg(short = 'd', long)]
 	pub directory: Option<String>,
 
-	/// Define a regexp pattern to filter available tags when determining the latest tag
-	#[arg(long)]
-	pub tag_filter: Option<String>,
-
-	/// If set, the remote does not need to have GPG key(s) defined
-	#[arg(long)]
+	/// (Optional) If set, the remote does not need to have a .gt/signing-key.public.asc defined
+	#[arg(long, default_value_t = false)]
 	pub unsecure: bool,
 
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<String>,
+	#[command(flatten)]
+	pub working_directory: WorkingDirectoryArg,
 }
 
 pub fn run(_args: RemoteAddArgs) {

--- a/src/commands/remote/list.rs
+++ b/src/commands/remote/list.rs
@@ -1,11 +1,11 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::WorkingDirectoryArg;
 
 #[derive(Args)]
 pub struct RemoteListArgs {
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	#[command(flatten)]
+	pub working_directory: WorkingDirectoryArg,
 }
 
 pub fn run(_args: RemoteListArgs) {

--- a/src/commands/remote/remove.rs
+++ b/src/commands/remote/remove.rs
@@ -1,19 +1,18 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::{RemoteArg, WorkingDirectoryArg};
 
 #[derive(Args)]
 pub struct RemoteRemoveArgs {
-	/// Define the name of the remote which shall be removed
-	#[arg(short = 'r', long)]
-	pub remote: String,
+	#[command(flatten)]
+	pub remote: RemoteArg,
 
-	/// If set, then all files defined in the remote's pulled.tsv are deleted as well
-	#[arg(long)]
+	/// (Optional) If defined, then all files defined in the remote's pulled.tsv are deleted as well
+	#[arg(long, default_value_t = false)]
 	pub delete_pulled_files: bool,
 
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	#[command(flatten)]
+	pub working_directory: WorkingDirectoryArg,
 }
 
 pub fn run(_args: RemoteRemoveArgs) {

--- a/src/commands/repull.rs
+++ b/src/commands/repull.rs
@@ -1,23 +1,19 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::PullCommonArgs;
 
 #[derive(Args)]
 pub struct RePullArgs {
-	/// If set, only the remote with this name is re-pulled, otherwise all are re-pulled
+	/// (Optional) If set, only files from the remote with this name is re-pulled, otherwise all are re-pulled
 	#[arg(short = 'r', long)]
 	pub remote: Option<String>,
 
-	/// If set, then only files which do not exist locally are pulled
+	/// (Optional) f defined, then only files which do not exist locally are pulled
 	#[arg(long, default_value_t = true)]
 	pub only_missing: bool,
 
-	/// If set and GPG is not set up yet, then all keys are imported without manual consent
-	#[arg(long)]
-	pub auto_trust: bool,
-
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	#[command(flatten)]
+	pub pull_common: PullCommonArgs,
 }
 
 pub fn run(_args: RePullArgs) {

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,19 +1,19 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::WorkingDirectoryArg;
 
 #[derive(Args)]
 pub struct ResetArgs {
-	/// If set, only the remote with this name is reset, otherwise all are reset
+	/// (Optional) If set, only the remote with this name is reset, otherwise all are reset
 	#[arg(short = 'r', long)]
 	pub remote: Option<String>,
 
-	/// If set, then only the gpg keys are reset but the files are not re-pulled
-	#[arg(long)]
-	pub gpg_only: bool,
+	/// (Optional) If defined, then only the gpg keys are reset but the files are not re-pulled
+	#[arg(long, default_value_t = false)]
+	pub only_gpg: bool,
 
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	#[command(flatten)]
+	pub working_directory: WorkingDirectoryArg,
 }
 
 pub fn run(_args: ResetArgs) {

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -2,8 +2,8 @@ use clap::Args;
 
 #[derive(Args)]
 pub struct SelfUpdateArgs {
-	/// If set, then install.sh will be called even if gt is already on latest tag
-	#[arg(long)]
+	/// (Optional) If Defined, then install.sh will be called even if gt is already on latest tag
+	#[arg(long, default_value_t = false)]
 	pub force: bool,
 }
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,27 +1,23 @@
 use clap::Args;
-use std::path::PathBuf;
+
+use crate::commands::common_args::PullCommonArgs;
 
 #[derive(Args)]
 pub struct UpdateArgs {
-	/// If set, only the files of this remote are updated, otherwise all
+	/// (Optional) If set, only the files of this remote are updated, otherwise all
 	#[arg(short = 'r', long)]
 	pub remote: Option<String>,
 
-	/// Define from which tag files shall be pulled, only valid if remote via -r is specified
+	/// (Optional) define from which tag files shall be pulled, only valid if <REMOTE> is specified
 	#[arg(short = 't', long)]
 	pub tag: Option<String>,
 
-	/// If set, then no files are updated and instead a list with updatable files is output
-	#[arg(long)]
+	/// (Optional) If defined, then no files are updated and instead a list with updatable files including versions is output
+	#[arg(long, default_value_t = false)]
 	pub list: bool,
 
-	/// If set and GPG is not set up yet, then all keys are imported without manual consent
-	#[arg(long)]
-	pub auto_trust: bool,
-
-	/// Path which gt shall use as working directory -- default: .gt
-	#[arg(short = 'w', long)]
-	pub working_directory: Option<PathBuf>,
+	#[command(flatten)]
+	pub pull_common: PullCommonArgs,
 }
 
 pub fn run(_args: UpdateArgs) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod commands;
 
 #[derive(Parser)]
 #[command(name = "gt")]
-#[command(about, version,author, disable_help_subcommand = true)]
+#[command(about, version, author, disable_help_subcommand = true)]
 struct Cli {
 	#[command(subcommand)]
 	command: commands::Commands,


### PR DESCRIPTION
The derive pattern doesn't allow to overwrite the documentation, we would need to use the builder to reduce the duplication even further. We stick with the derive-approach for now as it is more readable and might switch to the builder in the future.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/gt/blob/v1.6.3/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
